### PR TITLE
remove newline characters when RPCError display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 <!-- markdownlint-disable-file MD041 -->
 
+* remove newline characters in `error-path` and `error-info>bad-element` and start or end of `error-message` when RPCError display
+
 ## 0.4.0 (October 21, 2021)
 
 * enhance RPCError display with the `error-path` and `error-info>bad-element` values if set

--- a/netconf/rpc.go
+++ b/netconf/rpc.go
@@ -12,6 +12,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"strings"
 )
 
 // RPCMessage represents an RPC Message to be sent.
@@ -98,13 +99,24 @@ func (re *RPCError) Error() string {
 	if re.Path != "" {
 		if re.BadElement != "" {
 			return fmt.Sprintf("netconf rpc [%s]\n%s\n  '%s'\n    %s",
-				re.Severity, re.Path, re.BadElement, re.Message)
+				re.Severity,
+				strings.Trim(re.Path, "\n"),
+				strings.Trim(re.BadElement, "\n"),
+				strings.TrimSuffix(strings.TrimPrefix(re.Message, "\n"), "\n"),
+			)
 		}
 
-		return fmt.Sprintf("netconf rpc [%s]\n%s\n  %s", re.Severity, re.Path, re.Message)
+		return fmt.Sprintf("netconf rpc [%s]\n%s\n  %s",
+			re.Severity,
+			strings.Trim(re.Path, "\n"),
+			strings.TrimSuffix(strings.TrimPrefix(re.Message, "\n"), "\n"),
+		)
 	}
 
-	return fmt.Sprintf("netconf rpc [%s] %s", re.Severity, re.Message)
+	return fmt.Sprintf("netconf rpc [%s] %s",
+		re.Severity,
+		strings.TrimSuffix(strings.TrimPrefix(re.Message, "\n"), "\n"),
+	)
 }
 
 // RPCMethod defines the interface for creating an RPC method.


### PR DESCRIPTION
* remove newline characters in `error-path` and `error-info>bad-element` and start or end of `error-message` when RPCError display
