### PR TITLE
deps: bump golang and module golang.org/x/crypto 

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,28 +1,28 @@
 name: Go Tests
 on: [push, pull_request]
 jobs:
-  test-1_21:
-    name: Test 1.21
+  test-1_23:
+    name: Test 1.23
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.21
+      - name: Set up Go 1.23
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.23'
         id: go
       - name: Check out code
         uses: actions/checkout@v4
       - name: Test
         run: go test -v ./...
 
-  test-1_22:
-    name: Test 1.22
+  test-1_24:
+    name: Test 1.24
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.22
+      - name: Set up Go 1.24
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24'
         id: go
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -5,10 +5,10 @@ jobs:
     name: Run
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.22
+      - name: Set up Go 1.24
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.24
           check-latest: true
         id: go
       - name: Check out code
@@ -16,5 +16,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.58
+          version: v1.64.7
           args: -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 <!-- markdownlint-disable-file MD041 -->
 
+* golang: bump minimum version to v1.23
+* deps: bump golang.org/x/crypto to v0.36.0
+
 ## 0.5.0 (2024-05-03)
 
 * transport: rewrite message when receive EOF before end of netconf message receipt

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It's a fork of [https://github.com/Juniper/go-netconf](https://github.com/Junipe
 
 ## Install
 
-* Requires Go 1.21 or later!
+* Requires Go 1.23.0 or later!
 * `go get github.com/jeremmfr/go-netconf/netconf`
 
 ## Example

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,13 @@
 module github.com/jeremmfr/go-netconf
 
-go 1.21
+go 1.23.0
 
 require (
 	github.com/google/go-cmp v0.7.0
-	golang.org/x/crypto v0.33.0
+	golang.org/x/crypto v0.36.0
 )
 
 require (
-	golang.org/x/sys v0.30.0 // indirect
-	golang.org/x/term v0.29.0 // indirect
+	golang.org/x/sys v0.31.0 // indirect
+	golang.org/x/term v0.30.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-golang.org/x/crypto v0.33.0 h1:IOBPskki6Lysi0lo9qQvbxiQ+FvsCC/YWOecCHAixus=
-golang.org/x/crypto v0.33.0/go.mod h1:bVdXmD7IV/4GdElGPozy6U7lWdRXA4qyRVGJV57uQ5M=
-golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
-golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/term v0.29.0 h1:L6pJp37ocefwRRtYPKSWOWzOtWSxVajvz2ldH/xi3iU=
-golang.org/x/term v0.29.0/go.mod h1:6bl4lRlvVuDgSf3179VpIxBF0o10JUpXWOnI7nErv7s=
+golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
+golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/term v0.30.0 h1:PQ39fJZ+mfadBm0y5WlL4vlM7Sx1Hgf13sMIY2+QS9Y=
+golang.org/x/term v0.30.0/go.mod h1:NYYFdzHoI5wRh/h5tDMdMqCqPJZEuNqVR5xJLd/n67g=


### PR DESCRIPTION
* golang: bump minimum version to v1.23
* deps: bump golang.org/x/crypto to v0.36.0